### PR TITLE
DCS-317 Read-only access for prison staff who do not have the CA, DM or RO role.

### DIFF
--- a/routes/authuser.js
+++ b/routes/authuser.js
@@ -11,9 +11,8 @@ const profiles = {
   },
   RO: {
     name: 'Ryan Orton',
-    username: 'RO_USER_TEST',
+    username: 'AUTH_RO_USER_TEST',
     email: 'RO_USER@work',
-    activeCaseLoadId: 'BEL',
   },
   DM: {
     name: 'Diane Matthews',
@@ -38,26 +37,17 @@ const profiles = {
 const roles = {
   CA: [
     {
-      roleCode: 'LEI_LICENCE_CA',
-    },
-    {
-      roleCode: 'LICENCE_RO',
-    },
-    {
-      roleCode: 'LEI_LICENCE_DM',
+      roleCode: 'LICENCE_CA',
     },
   ],
   RO: [
-    {
-      roleCode: 'LEI_LICENCE_RO',
-    },
     {
       roleCode: 'LICENCE_RO',
     },
   ],
   DM: [
     {
-      roleCode: 'LEI_LICENCE_DM',
+      roleCode: 'LICENCE_DM',
     },
   ],
   NOMIS: [

--- a/routes/delius.js
+++ b/routes/delius.js
@@ -12,9 +12,20 @@ const teamC01T04 = {
 
 const deliusTeams = [teamC01T04]
 
+const AUTH_RO_USER_TEST = {
+  username: 'AUTH_RO_USER_TEST',
+  staffCode: 'DELIUS_ID_TEST',
+  email: 'hdc_test+RO_USER_TEST@digital.justice.gov.uk',
+  staff: {
+    forenames: 'FIRSTA',
+    surname: 'LASTA',
+  },
+  teams: deliusTeams,
+}
+
 const RO_USER_TEST = {
   username: 'RO_USER_TEST',
-  staffCode: 'DELIUS_ID_TEST',
+  staffCode: 'AUTH_DELIUS_ID_TEST',
   email: 'hdc_test+RO_USER_TEST@digital.justice.gov.uk',
   staff: {
     forenames: 'FIRSTA',
@@ -35,6 +46,7 @@ const RO_USER = {
 }
 
 const staffDetailsByUsername = {
+  AUTH_RO_USER_TEST,
   RO_USER_TEST,
   RO_USER,
 }

--- a/routes/helpers/caselistForUser.js
+++ b/routes/helpers/caselistForUser.js
@@ -16,7 +16,7 @@ module.exports = token => {
     username = accessToken.replace('-token', '')
   }
 
-  if (username.includes('_TEST')) {
+  if (username.includes('_TEST') || username.startsWith('UOF_')) {
     return hdcTestCandidates
   }
 


### PR DESCRIPTION
Support tests for prison staff who do not have a licences role, particularly `UOF_REVIEWER_USER`
* Add `AUTH_RO_USER_TEST` as an alternative to `RO_USER_TEST` because the former is not assigned the `PRISON` role by the auth service.
* Remove redundant roles codes like `LEI_LICENCE_DM`.
* Return the hdcTestCandidates caselist for usernames starting with `UOF_`.